### PR TITLE
Fix connection register error when connection arguments are not defined

### DIFF
--- a/class-config.php
+++ b/class-config.php
@@ -41,7 +41,7 @@ final class WPGraphQL_MB_Relationships_Config
   {
     $this->type_name = $settings['field']['post_type'];
     $this->connection_name = $settings['graphql_name'];
-    $this->connection_args = $settings['graphql_args'];
+    $this->connection_args = isset( $settings['graphql_args'] ) ? $settings['graphql_args'] : [];
     $this->type_object = get_post_type_object($this->type_name);
     $this->graphql_type_name = $this->type_object->graphql_single_name;
     if (array_key_exists('resolve', $settings)) {

--- a/class-mb-relationships.php
+++ b/class-mb-relationships.php
@@ -87,7 +87,7 @@ final class WPGraphQL_MB_Relationships
             'fromType'        => $from_config->graphql_type_name,
             'toType'          => $to_config->graphql_type_name,
             'fromFieldName'   => $from_config->connection_name,
-            'connectionArgs'  => isset($from_config->connection_args) ? $from_config->connection_args : [],
+            'connectionArgs'  => $from_config->connection_args,
             'resolveNode'     => $to_config->resolve !== null ? $to_config->resolve : $resolver->get_node_resolver(),
             'resolve'         => $to_config->resolve_node !== null ? $to_config->resolve_node : $resolver->get_resolver($to_config->type_name, $id, $direction),
           ]


### PR DESCRIPTION
Hi,

I think the clause must be in the class since it is created in previously, otherwise it breaks when you don't define the optional connection arguments.

Thanks